### PR TITLE
Make types mod public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ use std::{fs, io};
 
 mod error;
 mod section;
-mod types;
+pub mod types;
 
 #[derive(Debug, Default)]
 pub struct BeatmapLevel {


### PR DESCRIPTION
The rational behind this change is that while writing an application, I wrote a function that needs to accept a parameter of type:
`osu_beatmap_parser::types::general::Gamemode`.
I think we all agree that the type `Gamemode`, should be public, as well as many other types.