### PR TITLE
Make section public and update README code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,16 @@ This library was made according how a .osu beatmap file is structured explained 
 ### Parsing a beatmap file (.osu)
 ```rust
 use osu_beatmap_parser::BeatmapLevel;
+use std::path::Path;
 
 fn main() {
-    let beatmap_path = Path::from("./assets/examples/test.osu");
+    let beatmap_path = Path::new("./assets/examples/test.osu");
+    let mut beatmap: BeatmapLevel = BeatmapLevel::open(&beatmap_path).unwrap();
 
-    let beatmap: BeatmapLevel = BeatmapLevel::open(&beatmap_path).unwrap();
-    
     // Editing the approach rate
-    beatmap.difficulty.approach_rate = 9;
-    
+    beatmap.difficulty.approach_rate = 9.;
+
     // Getting all the hit objects
-    let objects = beatmap.hitobjects;
+    let objects = beatmap.hit_objects;
 }
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ use std::str::FromStr;
 use std::{fs, io};
 
 mod error;
-mod section;
+pub mod section;
 pub mod types;
 
 #[derive(Debug, Default)]


### PR DESCRIPTION
First of all, thanks for the library! I had this repository starred for a long time in hopes that maybe one day I would use it. And the day has come!

But while I was trying to use the library to match the object types, I have seen that the `section` module is private in `lib.rs`. This prevents users from matching the object params and many other enum variants like this:

```rust
let objects = beatmap.hit_objects;
objects
    .iter()
    .for_each(|object| match &object.object_params {
        HitObjectType::HitCircle => todo!(),
        HitObjectType::Slider(_) => todo!(),
        HitObjectType::Spinner(_) => todo!(),
        HitObjectType::ManiaHold(_) => todo!(),
    });
```

I also updated the readme example code. Although it's easy to fix the errors in the example to get it working, I wanted to include it  to the one liner pr.
