### PR TITLE
Fixing edge cases and rewriting section indexing / partitioning 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "Rust library to parse .osu beatmap file and manage beatmap data"
 version = "0.14.0"
 authors = ["Sailor SnoW <snxwin@pm.me>"]
 repository = "https://github.com/SailorSnoW/osu-beatmap-parser/"
-license =  "MIT/Apache-2.0"
+license = "MIT/Apache-2.0"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -15,16 +15,16 @@ This library was made according how a .osu beatmap file is structured explained 
 ### Parsing a beatmap file (.osu)
 ```rust
 use osu_beatmap_parser::BeatmapLevel;
+use std::path::Path;
 
 fn main() {
-    let beatmap_path = Path::from("./assets/examples/test.osu");
+    let beatmap_path = Path::new("./assets/examples/test.osu");
+    let mut beatmap: BeatmapLevel = BeatmapLevel::open(&beatmap_path).unwrap();
 
-    let beatmap: BeatmapLevel = BeatmapLevel::open(&beatmap_path).unwrap();
-    
     // Editing the approach rate
-    beatmap.difficulty.approach_rate = 9;
-    
+    beatmap.difficulty.approach_rate = 9.;
+
     // Getting all the hit objects
-    let objects = beatmap.hitobjects;
+    let objects = beatmap.hit_objects;
 }
 ```

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,6 +18,8 @@ pub enum BeatmapParseError {
     StoryboardEntry,
     #[error("The section seems to not be present in the beatmap file")]
     SectionNotFound { section: String },
+    #[error("The section is empty")]
+    EmptySection { section: String },
 }
 
 #[derive(Error, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,6 @@ impl FromStr for BeatmapLevel {
                             name: section_name.to_string(),
                             range: None,
                         });
-                        continue;
                     }
                 }
                 Some(index) => {
@@ -118,13 +117,9 @@ impl FromStr for BeatmapLevel {
                             name: previous_section_name.to_string(),
                             range: Some(previous_index..index),
                         });
-                        previous_index_option = Some(index);
-                        previous_section_name = section_name;
-                    } else {
-                        previous_index_option = Some(index);
-                        previous_section_name = section_name;
-                        continue;
                     }
+                    previous_index_option = Some(index);
+                    previous_section_name = section_name;
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ use std::str::FromStr;
 use std::{fs, io};
 
 mod error;
-mod section;
+pub mod section;
 pub mod types;
 
 #[derive(Debug, Default)]

--- a/src/section/editor.rs
+++ b/src/section/editor.rs
@@ -33,16 +33,21 @@ impl FromStr for EditorSection {
 
         let bookmarks: String = Self::get_field_name_value(&s, "Bookmarks")?;
 
-        editor.bookmarks = bookmarks
-            .split(',')
-            .map(|x| {
-                i32::from_str(x)
-                    .map_err(|_| InvalidFormat {
-                        field: "Bookmarks".to_string(),
-                    })
-                    .unwrap()
-            })
-            .collect();
+        if bookmarks.is_empty() {
+            editor.bookmarks = Vec::new();
+        } else {
+            editor.bookmarks = bookmarks
+                .split(',')
+                .map(|x| {
+                    i32::from_str(x)
+                        .map_err(|_| InvalidFormat {
+                            field: "Bookmarks".to_string(),
+                        })
+                        .unwrap()
+                })
+                .collect();
+        }
+
         editor.distance_spacing = Self::get_field_name_value(&s, "DistanceSpacing")?;
         editor.beat_divisor = Self::get_field_name_value(&s, "BeatDivisor")?;
         editor.grid_size = Self::get_field_name_value(&s, "GridSize")?;

--- a/src/section/hit_objects.rs
+++ b/src/section/hit_objects.rs
@@ -456,6 +456,12 @@ impl FromStr for HitObject {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let split: Vec<&str> = s.trim().splitn(6, ",").map(|x| x.trim()).collect();
+        if split == vec![""] {
+            Err(BeatmapParseError::EmptySection {
+                section: "HitObject".to_string(),
+            })?;
+        }
+
         let mut hit_object = HitObject::new();
 
         let object_type =

--- a/src/section/mod.rs
+++ b/src/section/mod.rs
@@ -136,6 +136,7 @@ impl<T: CommaListElement> FromStr for CommaListOf<T> {
                 Ok(x) => list.push(x),
                 Err(BeatmapParseError::CommentaryEntry) => (),
                 Err(BeatmapParseError::StoryboardEntry) => (),
+                Err(BeatmapParseError::EmptySection { section: _ }) => (),
                 Err(x) => return Err(x),
             }
         }

--- a/src/section/timing_points.rs
+++ b/src/section/timing_points.rs
@@ -13,7 +13,7 @@ use std::str::FromStr;
 pub struct TimingPoint {
     /// Start time of the timing section, in milliseconds from the beginning of the beatmap's audio.
     /// The end of the timing section is the next timing point's time (or never, if this is the last timing point).
-    pub time: u32,
+    pub time: f32,
     /// This property has two meanings:
     /// - For uninherited timing points, the duration of a beat, in milliseconds.
     /// - For inherited timing points, a negative inverse slider velocity multiplier, as a percentage.
@@ -40,7 +40,7 @@ impl FromStr for TimingPoint {
         let s: Vec<&str> = s.trim().split(",").map(|x| x.trim()).collect();
 
         Ok(TimingPoint {
-            time: u32::from_str(s[0]).map_err(|_| InvalidFormat {
+            time: f32::from_str(s[0]).map_err(|_| InvalidFormat {
                 field: "time".to_string(),
             })?,
             beat_length: f32::from_str(s[1]).map_err(|_| InvalidFormat {
@@ -90,7 +90,7 @@ mod tests {
     use crate::section::CommaListOf;
     use crate::section::Section;
 
-    const TEST_SECTION: &'static str = "10000,333.33,4,0,0,100,1,1
+    const TEST_SECTION: &'static str = "10000.3,333.33,4,0,0,100,1,1
 12000,-25,4,3,0,100,0,1
 ";
 
@@ -100,7 +100,7 @@ mod tests {
 
         assert_eq!(timing_points.len(), 2);
 
-        assert_eq!(timing_points[0].time, 10000);
+        assert_eq!(timing_points[0].time, 10000.3);
         assert_eq!(timing_points[0].beat_length, 333.33);
         assert_eq!(timing_points[0].meter, 4);
         assert_eq!(timing_points[0].sample_set, SampleSet::Default);
@@ -109,7 +109,7 @@ mod tests {
         assert_eq!(timing_points[0].is_uninherited, true.into());
         assert_eq!(timing_points[0].effects, Effects::KIAI);
 
-        assert_eq!(timing_points[1].time, 12000);
+        assert_eq!(timing_points[1].time, 12000.);
         assert_eq!(timing_points[1].beat_length, -25.0);
         assert_eq!(timing_points[1].meter, 4);
         assert_eq!(timing_points[1].sample_set, SampleSet::Drum);
@@ -123,7 +123,7 @@ mod tests {
     fn serialize_timing_points() {
         let mut timing_points: CommaListOf<TimingPoint> = CommaListOf::new();
         timing_points.push(TimingPoint {
-            time: 10000,
+            time: 10000.3,
             beat_length: 333.33,
             meter: 4,
             sample_set: SampleSet::Default,
@@ -133,7 +133,7 @@ mod tests {
             effects: Effects::KIAI,
         });
         timing_points.push(TimingPoint {
-            time: 12000,
+            time: 12000.,
             beat_length: -25.0,
             meter: 4,
             sample_set: SampleSet::Drum,
@@ -150,13 +150,13 @@ mod tests {
         use super::*;
         use crate::section::CommaListElement;
 
-        const TEST_TIMING_POINT: &'static str = "10000,333.33,4,0,0,100,1,1";
+        const TEST_TIMING_POINT: &'static str = "10000.3,333.33,4,0,0,100,1,1";
 
         #[test]
         fn parse_timing_point() {
             let timing_point = TimingPoint::parse(TEST_TIMING_POINT).unwrap();
 
-            assert_eq!(timing_point.time, 10000);
+            assert_eq!(timing_point.time, 10000.3);
             assert_eq!(timing_point.beat_length, 333.33);
             assert_eq!(timing_point.meter, 4);
             assert_eq!(timing_point.sample_set, SampleSet::Default);
@@ -169,7 +169,7 @@ mod tests {
         #[test]
         fn serialize_timing_point() {
             let timing_point = TimingPoint {
-                time: 10000,
+                time: 10000.3,
                 beat_length: 333.33,
                 meter: 4,
                 sample_set: SampleSet::Default,

--- a/src/types.rs
+++ b/src/types.rs
@@ -205,6 +205,8 @@ pub mod general {
     ///////////////////////////////////////////////////////////////////////////////////////////////
     #[derive(Debug, PartialEq, Eq)]
     pub enum SampleSet {
+        /// the value in sampleset field when the map is first created
+        NONE,
         NORMAL,
         SOFT,
         DRUM,
@@ -221,6 +223,7 @@ pub mod general {
 
         fn from_str(s: &str) -> Result<Self, Self::Err> {
             match s {
+                "None" => Ok(SampleSet::NONE),
                 "Normal" => Ok(SampleSet::NORMAL),
                 "Soft" => Ok(SampleSet::SOFT),
                 "Drum" => Ok(SampleSet::DRUM),
@@ -234,6 +237,7 @@ pub mod general {
     impl From<&SampleSet> for String {
         fn from(pos: &SampleSet) -> Self {
             match pos {
+                SampleSet::NONE => String::from("None"),
                 SampleSet::NORMAL => String::from("Normal"),
                 SampleSet::SOFT => String::from("Soft"),
                 SampleSet::DRUM => String::from("Drum"),


### PR DESCRIPTION
Hello again!

The library was not designed to handle new map files straight out of editor without timing points, bookmarks, hit objects, combo colours and the sample set. The code used a lot of unwraps so it was panicking for each of the cases. 

I changed bookmark logic to return an empty array if the bookmark string is empty and added a `None` variant to sample set because that's how it is in the .osu file
Also changed the timing value to float because it's possible to set it to decimal number in game if you use the "tap to time" thing.

For the sections, I first tried to make some sections optional and changed the code accordingly. but the logic in `lib.rs` became convoluted because of it. so I rewrote the whole section. It's a bit more complex now and I don't like making the code more complex but I feel like it was justified.
